### PR TITLE
Install runkit module

### DIFF
--- a/puppet/manifests/default.pp
+++ b/puppet/manifests/default.pp
@@ -67,6 +67,8 @@ php::module { "xdebug": } php::mod { "xdebug": }
 $mods = ["mysql", "curl", "mcrypt", "xdebug"]
 php::mod { "$mods": }
 
+php::pecl::module { "runkit": }
+
 class { '::mysql::server':
 	require => Exec['apt-update'],
 	root_password => 'vagrant',


### PR DESCRIPTION
Some unit tests require runkit, which should be easy to install on linux-based systems with PECL.

Note, I don't use vagrant, so I have no idea whether this works or not. Please can someone test that this works before merging :)

My intended changes are:

```
# pecl install runkit
```

php.ini:

```
runkit.internal_override = 1
```
